### PR TITLE
Add reference assembly to NuGet

### DIFF
--- a/CaptureTestApp.NuGet/CaptureTestApp.NuGet.csproj
+++ b/CaptureTestApp.NuGet/CaptureTestApp.NuGet.csproj
@@ -7,6 +7,6 @@
     <Platforms>x86;x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MMaitre.MediaCaptureWPF" Version="2.0.0-beta" />
+    <PackageReference Include="MMaitre.MediaCaptureWPF" Version="2.0.1-beta" />
   </ItemGroup>
 </Project>

--- a/MediaCaptureWPF.Native/AssemblyInfo.cpp
+++ b/MediaCaptureWPF.Native/AssemblyInfo.cpp
@@ -31,7 +31,7 @@ using namespace System::Security::Permissions;
 // You can specify all the value or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
-[assembly:AssemblyVersionAttribute("2.0.0")];
+[assembly:AssemblyVersionAttribute("2.0.1")];
 
 [assembly:ComVisible(false)];
 

--- a/Package/MMaitre.MediaCaptureWPF.nuspec
+++ b/Package/MMaitre.MediaCaptureWPF.nuspec
@@ -24,6 +24,10 @@
     <file src="..\MediaCaptureWPF\bin\x64\Release\net10.0-windows10.0.19041.0\Ijwhost.dll" target="build\net10.0\x64\" />
     <file src="..\MediaCaptureWPF\bin\x64\Release\net10.0-windows10.0.19041.0\MediaCaptureWPF.Native.dll" target="build\net10.0\x64\" />
 
+    <!-- reference -->
+    <file src="..\MediaCaptureWPF\ref\MediaCaptureWPF.dll" target="build\net10.0\ref\" />
+    <file src="..\MediaCaptureWPF\ref\MediaCaptureWPF.Native.dll" target="build\net10.0\ref\" />
+    
     <!-- build -->
     <file src="MMaitre.MediaCaptureWPF.targets" target="build\net10.0\" />
 

--- a/Package/MMaitre.MediaCaptureWPF.targets
+++ b/Package/MMaitre.MediaCaptureWPF.targets
@@ -1,10 +1,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Reference Include="MMaitre.MediaCaptureWPF">
-      <HintPath>$(MSBuildThisFileDirectory)\..\net10.0\$(PlatformTarget)\MediaCaptureWPF.dll</HintPath>
+    <Reference Include="MMaitre.MediaCaptureWPF" Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'x86'">
+      <HintPath>$(MSBuildThisFileDirectory)\..\net10.0\$(Platform)\MediaCaptureWPF.dll</HintPath>
     </Reference>
-    <Reference Include="MMaitre.MediaCaptureWPF.Native">
-      <HintPath>$(MSBuildThisFileDirectory)\..\net10.0\$(PlatformTarget)\MediaCaptureWPF.Native.dll</HintPath>
+    <Reference Include="MMaitre.MediaCaptureWPF.Native" Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'x86'">
+      <HintPath>$(MSBuildThisFileDirectory)\..\net10.0\$(Platform)\MediaCaptureWPF.Native.dll</HintPath>
+    </Reference>
+    <Reference Include="MMaitre.MediaCaptureWPF" Condition="'$(Platform)' == 'AnyCPU'">
+      <HintPath>$(MSBuildThisFileDirectory)\..\net10.0\ref\MediaCaptureWPF.dll</HintPath>
+    </Reference>
+    <Reference Include="MMaitre.MediaCaptureWPF.Native" Condition="'$(Platform)' == 'AnyCPU'">
+      <HintPath>$(MSBuildThisFileDirectory)\..\net10.0\ref\MediaCaptureWPF.Native.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Package/clean.cmd
+++ b/Package/clean.cmd
@@ -4,15 +4,20 @@ setlocal
 REM Clean up
 if exist .\Win32 rmdir /S /Q .\Win32
 if exist .\x64 rmdir /S /Q .\x64
+if exist .\Debug rmdir /S /Q .\Debug
 if exist .\Release rmdir /S /Q .\Release
 if exist ..\MediaCaptureWPF\bin rmdir /S /Q ..\MediaCaptureWPF\bin
 if exist ..\MediaCaptureWPF\obj rmdir /S /Q ..\MediaCaptureWPF\obj
-if exist ..\Debug rmdir /S /Q ..\Debug
+if exist ..\MediaCaptureWPF\ref rmdir /S /Q ..\MediaCaptureWPF\ref
+if exist ..\Win32 rmdir /S /Q ..\Win32
 if exist ..\x64 rmdir /S /Q ..\x64
+if exist ..\Debug rmdir /S /Q ..\Debug
 if exist ..\Release rmdir /S /Q ..\Release
+if exist ..\MediaCaptureWPF.Native\Win32 rmdir /S /Q ..\MediaCaptureWPF.Native\Win32
+if exist ..\MediaCaptureWPF.Native\x64 rmdir /S /Q ..\MediaCaptureWPF.Native\x64
 if exist ..\MediaCaptureWPF.Native\Debug rmdir /S /Q ..\MediaCaptureWPF.Native\Debug
 if exist ..\MediaCaptureWPF.Native\Release rmdir /S /Q ..\MediaCaptureWPF.Native\Release
-if exist ..\MediaCaptureWPF.Native\x64 rmdir /S /Q ..\MediaCaptureWPF.Native\x64
+if exist ..\MediaSink\Win32 rmdir /S /Q ..\MediaSink\Win32
+if exist ..\MediaSink\x64 rmdir /S /Q ..\MediaSink\x64
 if exist ..\MediaSink\Debug rmdir /S /Q ..\MediaSink\Debug
 if exist ..\MediaSink\Release rmdir /S /Q ..\MediaSink\Release
-if exist ..\MediaSink\x64 rmdir /S /Q ..\MediaSink\x64

--- a/Package/pack.cmd
+++ b/Package/pack.cmd
@@ -12,6 +12,12 @@ if %ERRORLEVEL% NEQ 0 goto eof
 msbuild -restore -v:m .\pack.sln /maxcpucount /target:build /nologo /p:Configuration=Release /p:Platform=x64
 if %ERRORLEVEL% NEQ 0 goto eof
 
+REM Build Ref
+refasmer -v --all -n -O ..\MediaCaptureWPF\ref ..\MediaCaptureWPF\bin\x86\Release\net10.0-windows10.0.19041.0\MediaCaptureWPF.Native.dll
+if %ERRORLEVEL% NEQ 0 goto eof
+refasmer -v --all -n -O ..\MediaCaptureWPF\ref ..\MediaCaptureWPF\bin\x86\Release\net10.0-windows10.0.19041.0\MediaCaptureWPF.dll
+if %ERRORLEVEL% NEQ 0 goto eof
+
 REM Pack
 nuget.exe pack MMaitre.MediaCaptureWPF.nuspec -OutputDirectory Packages -Prop NuGetVersion=%VERSION% -NoPackageAnalysis
 if %ERRORLEVEL% NEQ 0 goto eof

--- a/Package/pack.cmd
+++ b/Package/pack.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal enableextensions
 
-set VERSION=2.0.0-beta
+set VERSION=2.0.1-beta
 
 REM Clean
 call .\clean.cmd


### PR DESCRIPTION
- generate reference assembly with `refasmer`, `pack.cmd` needs to have `refasmer` in the PATH
- modify .target to add reference assembly when AnyCPU is targeted